### PR TITLE
feat(32): 서비스헤더 버튼 메뉴 반응형 추가 및 Toast 자동 삭제 추가

### DIFF
--- a/src/components/Button/ButtonOutlined.module.css
+++ b/src/components/Button/ButtonOutlined.module.css
@@ -45,7 +45,7 @@
   &.iconButton {
     gap: 10px;
     width: auto;
-    padding: 9px 16px;
+    padding: 9px;
   }
 }
 
@@ -60,7 +60,7 @@
   &.iconButton {
     gap: 4px;
     width: auto;
-    padding: 6px 16px;
+    padding: 9px;
   }
 }
 

--- a/src/components/Button/ButtonOutlined.module.css
+++ b/src/components/Button/ButtonOutlined.module.css
@@ -1,4 +1,7 @@
 .outlinedButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border-radius: 6px;
   border: 1px solid var(--gray-300);
   background-color: var(--white);

--- a/src/components/Button/ButtonPrimary.module.css
+++ b/src/components/Button/ButtonPrimary.module.css
@@ -1,4 +1,7 @@
 .primaryButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: none;
   background-color: #9747ff;
   color: var(--white);

--- a/src/components/Button/ButtonSecondary.module.css
+++ b/src/components/Button/ButtonSecondary.module.css
@@ -1,4 +1,7 @@
 .btn-secondary-40 {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 122px;
   height: 40px;
   border-radius: 6px;

--- a/src/components/ServiceHeader/ReactionSection.jsx
+++ b/src/components/ServiceHeader/ReactionSection.jsx
@@ -6,7 +6,10 @@ import ArrowButton from "../ArrowButton/ArrowButton"
 import useRequest from "../../hooks/useRequest"
 import styles from "./ReactionSection.module.css"
 
-const REACTIONS_LIMIT = 8
+const REACTIONS_LIMIT = {
+  small: 6,
+  medium: 8,
+}
 
 const ReactionSection = ({ id, screenSize }) => {
   const emojisRef = useRef(null)
@@ -23,12 +26,12 @@ const ReactionSection = ({ id, screenSize }) => {
     const { data, error } = await request({
       url: `recipients/${id}/reactions/`,
       method: "get",
-      params: { limit: REACTIONS_LIMIT, offset: offset },
+      params: { limit: REACTIONS_LIMIT[screenSize], offset: offset },
     })
 
     if (data) setReactions(data)
     else if (error) alert("오류로 리액션을 불러오는데에 실패하였습니다.")
-  }, [id, offset, request])
+  }, [id, offset, request, screenSize])
 
   const getTopReactions = useCallback(async () => {
     const { data } = await request({
@@ -131,13 +134,17 @@ const ReactionSection = ({ id, screenSize }) => {
                 {reactions.previous && (
                   <ArrowButton
                     direction="left"
-                    onClick={() => setOffset((prev) => prev - REACTIONS_LIMIT)}
+                    onClick={() =>
+                      setOffset((prev) => prev - REACTIONS_LIMIT[screenSize])
+                    }
                   />
                 )}
                 {reactions.next && (
                   <ArrowButton
                     direction="right"
-                    onClick={() => setOffset((prev) => prev + REACTIONS_LIMIT)}
+                    onClick={() =>
+                      setOffset((prev) => prev + REACTIONS_LIMIT[screenSize])
+                    }
                   />
                 )}
               </div>

--- a/src/components/ServiceHeader/ReactionSection.module.css
+++ b/src/components/ServiceHeader/ReactionSection.module.css
@@ -38,8 +38,13 @@
   border-radius: 8px;
   background-color: var(--white);
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-  overflow-y: auto;
-  z-index: 100;
+  overflow-y: hidden;
+  z-index: 2;
+
+  @media (max-width: 768px) {
+    width: 236px;
+    height: 138px;
+  }
 
   .allEmojis {
     display: flex;
@@ -52,8 +57,6 @@
     margin-bottom: 10px;
 
     > button {
-      /* margin-right: 8px; */
-      /* margin-bottom: 10px; */
       background-color: transparent;
       cursor: pointer;
     }
@@ -91,12 +94,9 @@
     top: 56px;
     right: 0;
     z-index: 100;
-  }
 
-  @media (min-width: 768px) {
-    > button {
-      /* width: 36px;
-      height: 32px; */
+    @media (max-width: 768px) {
+      max-width: 286px;
     }
   }
 }

--- a/src/components/ServiceHeader/ServiceHeader.jsx
+++ b/src/components/ServiceHeader/ServiceHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import Button from "../Button/Button"
 import ContributorsInfo from "../ContributorsInfo/ContributorsInfo"
 import ReactionSection from "./ReactionSection"
@@ -19,6 +19,7 @@ const ServiceHeader = ({ recipient }) => {
   const [screenSize, setScreenSize] = useState("medium")
   const [showDropdown, setShowDropdown] = useState(false)
   const [showToast, setShowToast] = useState(false)
+  const dropdownRef = useRef()
   const { width } = useWindowSize()
 
   useEffect(() => {
@@ -36,6 +37,27 @@ const ServiceHeader = ({ recipient }) => {
     setShowDropdown(false)
     setShowToast(true)
   }
+
+  useEffect(() => {
+    const handleOutsideClose = (e) => {
+      if (showDropdown && !dropdownRef.current.contains(e.target))
+        setShowDropdown(false)
+    }
+
+    document.addEventListener("click", handleOutsideClose)
+
+    return () => document.removeEventListener("click", handleOutsideClose)
+  }, [showDropdown])
+
+  useEffect(() => {
+    if (showToast) {
+      const timer = setTimeout(() => {
+        setShowToast((prevState) => !prevState)
+      }, 3000)
+
+      return () => clearTimeout(timer)
+    }
+  }, [showToast])
 
   return (
     <div className={styles.header}>
@@ -64,7 +86,7 @@ const ServiceHeader = ({ recipient }) => {
 
           <div className={styles.line} />
 
-          <div className={styles.shareSection}>
+          <div className={styles.shareSection} ref={dropdownRef}>
             <Button.Outlined
               icon="share"
               size="36"

--- a/src/components/ServiceHeader/ServiceHeader.module.css
+++ b/src/components/ServiceHeader/ServiceHeader.module.css
@@ -60,6 +60,7 @@
 
   > button {
     width: 56px;
+    height: 36px;
   }
 
   .dropdownList {
@@ -71,6 +72,7 @@
     background-color: var(--white);
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
     z-index: 100;
+    overflow: hidden;
 
     > button {
       width: 130px;
@@ -83,12 +85,7 @@
       }
     }
 
-    > button:first-of-type {
-      border-radius: 8px 8px 0 0;
-    }
-
     > button:last-or-type {
-      border-radius: 0 0 8px 8px;
       border-bottom: none;
     }
   }

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -4,6 +4,7 @@
   bottom: 70px;
   left: 50%;
   width: 524px;
+  max-width: 90vw;
   height: 64px;
   transform: translateX(-50%);
   background-color: rgba(0, 0, 0, 0.8);
@@ -13,6 +14,7 @@
   z-index: 1;
   align-items: center;
   gap: 12px;
+  z-index: 2;
 }
 
 .toast-content {


### PR DESCRIPTION
## 🔘 Part

- [x] FE

<br/>

## 🔎 작업 내용
 
클릭하면 나오는 이모지 피커 같은 부분들이 반응형 고려가 전혀 안되어있길래 작업했고
url 복사시 나오는 toast가 버튼을 눌러서 삭제도 가능하지만 3초뒤에 자동으로 사라지도록 코드 추가했습니다!
제가 저번 서비스헤더 pr때 버튼을 잘못건드려서 좀 스타일이 바뀐거 같아가지구 그 부분도 같이 수정해서 올려놨습니다


  <br/>

이미지 첨부

<br/>

## 🔧 앞으로의 과제

임시 배포랑 카톡공유기능 추가하기
  <br/>

## ➕ 이슈 링크

[레포 이름 #이슈번호](이슈 주소)
